### PR TITLE
Port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ This tap:
    Create a JSON file called `config.json`. Its contents should look like:
 
    ```json
-    {
-        "db2_system": "127.0.0.1",
-        "db2_uid": "your-db2-username",
-        "db2_pwd": "your-db2-password"
-    }
-    ```
+   {
+       "db2_system": "127.0.0.1",
+       "db2_uid": "your-db2-username",
+       "db2_pwd": "your-db2-password"
+   }
+   ```
+
+   If you need to use a custom port (the default being 8471), see [Custom
+   Ports](#custom-ports) for more information.
 
 3. Run the tap in discovery mode
 
@@ -44,6 +47,26 @@ This tap:
    ```
    tap-db2 -c config.json -p catalog.json
    ```
+
+## Custom Ports
+
+This tap supports using a custom port to connect to your DB2 instance, but
+there are some important considerations. The IBM ODBC driver has a roundabout
+way of determining the port to connect to. The process the tap takes to
+configure the port is:
+
+- Update the `~/.iSeriesAccess/cwb_userprefs.ini` file and set `Port lookup
+  mode` to `1`, which tells the driver to use the `/etc/services` file as a
+  lookup for the port to use.
+- Update the `/etc/services` file to set the `as-database` port to whatever
+  port has been chosen.
+
+In order to write the port to `/etc/services`, the tap must be run as a user
+that has write permissions on it.
+
+The tap does not make any effort to restore these files to their original
+settings. Be aware that the modifications to these files may affect any other
+software on your system that may use them.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ The tap does not make any effort to restore these files to their original
 settings. Be aware that the modifications to these files may affect any other
 software on your system that may use them.
 
+When you are ready to use your custom port, you can update your `config.json`
+to use the `db2_port` option, likeso:
+
+```
+{
+  "db2_system": "some-host",
+  "db2_port": 1234
+}
+```
+
 ---
 
 Copyright &copy; 2017 Stitch

--- a/tap_db2/__init__.py
+++ b/tap_db2/__init__.py
@@ -2,7 +2,7 @@
 import singer
 from singer import utils
 from singer.catalog import Catalog
-from . import resolve, sync, discovery
+from . import resolve, sync, discovery, common
 
 REQUIRED_CONFIG_KEYS = ["db2_system", "db2_uid", "db2_pwd"]
 LOGGER = singer.get_logger()
@@ -16,6 +16,7 @@ def do_sync(args, input_catalog):
 
 def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
+    common.setup_port_configuration(args.config)
     if args.discover:
         discovery.discover(args.config).dump()
         print()

--- a/tap_db2/common.py
+++ b/tap_db2/common.py
@@ -1,7 +1,36 @@
+import os
+import re
+import shutil
 import pyodbc
 import backoff
 
 # pylint: disable=no-member
+
+userprefs = """
+[CWB_CURRUSER\Software\IBM\Client Access Express\CurrentVersion\Environments\My Connections\127.0.0.1\Communication]
+Port lookup mode=attr_dwd:0x00000001
+"""
+
+
+def write_userprefs():
+    userprefs_fname = os.path.expanduser("~/.iSeriesAccess/cwb_userprefs.ini")
+    if not os.path.exists(userprefs_fname):
+        os.makedirs(os.path.dirname(userprefs_fname), 0o700, exist_ok=True)
+        with open(userprefs_fname, "w") as f:
+            f.write(userprefs)
+
+
+def write_services_port(port, backup_first=True):
+    if backup_first:
+        shutil.copyfile("/etc/services", "/etc/services.backup")
+    with open("/etc/services", "r+") as f:
+        lines = f.readlines()
+        f.seek(0)
+        for line in lines:
+            if not re.match(r"^as-database\s+", line):
+                f.write(line)
+        f.truncate()
+        f.write("as-database {}/tcp\n".format(port))
 
 
 @backoff.on_exception(backoff.expo,

--- a/tap_db2/common.py
+++ b/tap_db2/common.py
@@ -9,6 +9,13 @@ import backoff
 
 
 def _write_userprefs(host, port):
+    """Creates or updates the ~/.iSeriesAccess/cwb_userprefs.ini file to
+    specify a "Port lookup mode", which controls how the driver determines
+    which port to use when connecting."""
+    # This file and its values were found by chris@stitchdata.com using strace,
+    # educated guesses, and hints from random docs on the internet. At the time
+    # of this writing, I could not find any specific documentation on this file
+    # or its options.
     config = configparser.ConfigParser()
     fname = os.path.expanduser("~/.iSeriesAccess/cwb_userprefs.ini")
     if not os.path.exists(fname):
@@ -28,10 +35,14 @@ def _write_userprefs(host, port):
 
 
 def _write_port_to_services(port):
+    """Modifies the /etc/services file to specify a port for connecting to
+    DB2."""
     with open("/etc/services", "r+") as f:
         lines = f.readlines()
         f.seek(0)
         for line in lines:
+            # as-database was found in
+            # https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_71/rzaii/rzaiiservicesandports.htm
             if not re.match(r"^as-database\s+", line):
                 f.write(line)
         f.truncate()
@@ -51,6 +62,8 @@ def setup_port_configuration(config):
                       max_tries=5,
                       factor=2)
 def connection(config):
+    # Docs on keywords this driver accepts:
+    # https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_71/rzaik/rzaikconnstrkeywordsgeneralprop.htm
     return pyodbc.connect(
         driver="{iSeries Access ODBC Driver 64-bit}",
         system=config["db2_system"],


### PR DESCRIPTION
Adds support for a `db2_port` option in the config when using a custom port.

See docstrings for some explanations.

Tested by specifying a custom port that was not valid, confirmed connection failed. Then switched to a custom port that was valid, the connection was good. Then changed my SSH tunnel to use the standard 8471 port, removed the `db2_port` from config, and once again the connection was good.