### PR TITLE
Do not support columns with ccsid of 65535

### DIFF
--- a/tap_db2/discovery/__init__.py
+++ b/tap_db2/discovery/__init__.py
@@ -19,6 +19,7 @@ Column = namedtuple("Column", [
     "character_maximum_length",
     "numeric_precision",
     "numeric_scale",
+    "ccsid",
 ])
 
 SUPPORTED_TYPES = {"T", "V", "P"}
@@ -63,7 +64,8 @@ def _query_columns(config):
                    data_type,
                    character_maximum_length,
                    numeric_precision,
-                   numeric_scale
+                   numeric_scale,
+                   ccsid
               FROM qsys2.syscolumns
         """)
         yield from cursor

--- a/tap_db2/discovery/schemas.py
+++ b/tap_db2/discovery/schemas.py
@@ -22,6 +22,9 @@ STRING_TYPES = {
     "char",
     "varchar",
 }
+UNSUPPORTED_CCSIDS = {
+    65535,
+}
 
 # https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_71/db2/rbafzch2datetime.htm
 DATETIME_TYPES = {
@@ -63,9 +66,13 @@ def _for_column(col, pk_columns):
         result.minimum = -10 ** (col.numeric_precision - col.numeric_scale)
         result.multipleOf = 10 ** (0 - col.numeric_scale)
     elif data_type in STRING_TYPES:
-        result.type = ["null", "string"]
-        if col.character_maximum_length > 0:
-            result.maxLength = col.character_maximum_length
+        if col.ccsid in UNSUPPORTED_CCSIDS:
+            err = "Unsupported CCSID {}".format(col.ccsid)
+            result = Schema(None, inclusion="unsupported", description=err)
+        else:
+            result.type = ["null", "string"]
+            if col.character_maximum_length > 0:
+                result.maxLength = col.character_maximum_length
     elif data_type in DATETIME_TYPES:
         result.type = ["null", "string"]
         result.format = "date-time"


### PR DESCRIPTION
These columns represent binary data, as described in
https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_71/db2/rbafzcatsyscol.htm
and
https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_71/db2/rbafzcharsubtype.htm

To test this, I ran a discovery and confirmed that only columns with this CCSID were marked unsupported. I then ran a sync of just one table that contained one of these columns.