### PR TITLE
Docker dev setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+LICENSE
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ state.json
 
 /private*
 /bin
+/ibm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.5
+
+RUN \
+    apt-get update && \
+    apt-get install -y unixodbc unixodbc-dev
+
+COPY ibm /opt/ibm
+
+RUN \
+    ln -s /opt/ibm/iSeriesAccess/lib64/libcwbcore.so /usr/lib/libcwbcore.so && \
+    ln -s /opt/ibm/iSeriesAccess/lib64/libcwbodbc.so /usr/lib/libcwbodbc.so && \
+    ln -s /opt/ibm/iSeriesAccess/lib64/libcwbodbcs.so /usr/lib/libcwbodbcs.so && \
+    ln -s /opt/ibm/iSeriesAccess/lib64/libcwbrc.so /usr/lib/libcwbrc.so && \
+    ln -s /opt/ibm/iSeriesAccess/lib64/libcwbxda.so /usr/lib/libcwbxda.so && \
+    ln -s /opt/ibm/lib/libdb2clixml4c.so /usr/lib/libdb2clixml4c.so && \
+    ln -s /opt/ibm/lib/libdb2clixml4c.so.1 /usr/lib/libdb2clixml4c.so.1 && \
+    ln -s /opt/ibm/lib/libdb2o.so /usr/lib/libdb2o.so && \
+    ln -s /opt/ibm/lib/libdb2o.so.1 /usr/lib/libdb2o.so.1 && \
+    ln -s /opt/ibm/lib/libdb2.so /usr/lib/libdb2.so && \
+    ln -s /opt/ibm/lib/libdb2.so.1 /usr/lib/libdb2.so.1 && \
+    ln -s /opt/ibm/lib/libDB2xml4c.so /usr/lib/libDB2xml4c.so && \
+    ln -s /opt/ibm/lib/libDB2xml4c.so.58 /usr/lib/libDB2xml4c.so.58 && \
+    ln -s /opt/ibm/lib/libDB2xml4c.so.58.0 /usr/lib/libDB2xml4c.so.58.0
+
+COPY docker/odbcinst.ini /etc/odbcinst.ini
+
+ENV PYTHONPATH /opt/code/tap-db2
+RUN mkdir -p /opt/code/tap-db2
+COPY ./setup.py /opt/code/tap-db2/setup.py
+COPY ./tap_db2 /opt/code/tap-db2/tap_db2
+RUN pip install /opt/code/tap-db2
+
+WORKDIR /opt/code/tap-db2
+ENTRYPOINT ["python", "-m", "tap_db2"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -106,7 +106,20 @@ If you have this directory, first build the container with
 And now, to run, you must have a config file described above. Set the `host` to
 `localhost` and the port to `8471`. This assumes you have the port 8471 setup
 locally which forwards to a DB2 instance (for example, you may have an SSH
-tunnel running with a command like `ssh -L 8471:db2-host:8471 ssh-host`).
+tunnel running with a command like `ssh -L 8471:db2-host:8471 ssh-host`). Now
+run:
+
+
+```
+./docker/run
+```
+
+This will invoke the tap and share this repositories directory into it. You can
+provide all the usual flags the tap accepts, like:
+
+```
+./docker/run --config config.json --discover
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ to use the `port` option, likeso:
 }
 ```
 
+## Development Using Docker
+
+A Dockerfile is provided to aide development of the tap. To use, you must first
+have a copy of the IBM drivers in a directory in this repository called `ibm`.
+Obtaining this is currently outside the scope of these instructions. The
+drivers are proprietary and thus they cannot be included.
+
+If you have this directory, first build the container with
+
+```
+./docker/build
+```
+
+And now, to run, you must have a config file described above. Set the `host` to
+`localhost` and the port to `8471`. This assumes you have the port 8471 setup
+locally which forwards to a DB2 instance (for example, you may have an SSH
+tunnel running with a command like `ssh -L 8471:db2-host:8471 ssh-host`).
+
 ---
 
 Copyright &copy; 2017 Stitch

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t tap-db2 .

--- a/docker/odbcinst.ini
+++ b/docker/odbcinst.ini
@@ -1,0 +1,21 @@
+##########################################################################
+# 64 bit entry using common driver name
+[iSeries Access ODBC Driver]
+Description = iSeries Access for Linux ODBC Driver
+Driver      = /opt/ibm/iSeriesAccess/lib64/libcwbodbc.so
+Setup       = /opt/ibm/iSeriesAccess/lib64/libcwbodbcs.so
+NOTE1= If using unixODBC 2.2.11 or later and you want the 32 and 64-bit ODBC drivers to share DSN's,
+NOTE2= the following Driver64/Setup64 keywords will provide that support.
+Driver64    = /opt/ibm/iSeriesAccess/lib64/libcwbodbc.so
+Setup64     = /opt/ibm/iSeriesAccess/lib64/libcwbodbcs.so
+Threading   = 2
+DontDLClose = 1
+
+##########################################################################
+# 64-bit entry using unique driver name
+[iSeries Access ODBC Driver 64-bit]
+Description = iSeries Access for Linux 64-bit ODBC Driver
+Driver      = /opt/ibm/iSeriesAccess/lib64/libcwbodbc.so
+Setup       = /opt/ibm/iSeriesAccess/lib64/libcwbodbcs.so
+Threading   = 2
+DontDLClose = 1

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker run \
+    --volume $PWD:/opt/code/tap-db2 \
+    --net=host \
+    tap-db2 "$@"

--- a/tap_db2/__main__.py
+++ b/tap_db2/__main__.py
@@ -1,0 +1,4 @@
+from tap_db2 import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a Dockerfile which can be used for developing the tap. It allows you to set up an SSH tunnel to a running DB2 instance and then run tap discovery and sync easily.

