### PR TITLE
Fix issue with bookmarking timestamp columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ run:
 ./docker/run
 ```
 
-This will invoke the tap and share this repositories directory into it. You can
+This will invoke the tap and share this repository's directory into it. You can
 provide all the usual flags the tap accepts, like:
 
 ```

--- a/tap_db2/sync.py
+++ b/tap_db2/sync.py
@@ -39,11 +39,19 @@ def _get_replication_key(state: dict, catalog_entry: CatalogEntry):
     return ReplicationKey(column, value)
 
 
+def _sql_data_type(catalog_entry, column):
+    return metadata.get(metadata.to_map(catalog_entry.metadata),
+                        breadcrumb=("properties", column),
+                        k="sql-datatype")
+
+
+def _is_timestamp_column(catalog_entry, column):
+    data_type = _sql_data_type(catalog_entry, column)
+    return data_type == "timestmp"  # No that's not a typo
+
+
 def _column_sql(catalog_entry: CatalogEntry, column: str):
-    data_type = metadata.get(metadata.to_map(catalog_entry.metadata),
-                             breadcrumb=("properties", column),
-                             k="sql-datatype")
-    if data_type == "timestmp":  # No that's not a typo
+    if _is_timestamp_column(catalog_entry, column):
         return "{} - CURRENT TIMEZONE".format(_quote(column))
     return _quote(column)
 
@@ -58,7 +66,10 @@ def _create_sql(catalog_entry: CatalogEntry, columns, rep_key: ReplicationKey):
     if not rep_key:
         return select, params
     if rep_key.value:
-        select += " WHERE {} >= ?".format(_quote(rep_key.column))
+        col_sql = _quote(rep_key.column)
+        if _is_timestamp_column(catalog_entry, rep_key.column):
+            col_sql += " - CURRENT TIMEZONE"
+        select += " WHERE {} >= ?".format(col_sql)
         params = (rep_key.value,)
     select += " ORDER BY {} ASC".format(_quote(rep_key.column))
     return select, params

--- a/tap_db2/sync.py
+++ b/tap_db2/sync.py
@@ -65,7 +65,7 @@ def _create_sql(catalog_entry: CatalogEntry, columns, rep_key: ReplicationKey):
     params = ()
     if not rep_key:
         return select, params
-    if rep_key.value:
+    if rep_key.value is not None:
         col_sql = _quote(rep_key.column)
         if _is_timestamp_column(catalog_entry, rep_key.column):
             col_sql += " - CURRENT TIMEZONE"


### PR DESCRIPTION
Fixes broken bookmarking when using a timestamp column for a bookmark. The issue is that the timestamps were incorrect. When we select data from the database, we use SQL such as

```
SELECT column_name - CURRENT TIMEZONE ...
```

In order to always receive python datetime objects that are in UTC. But this same logic was not being done when querying data later. This PR modifies the queries so that when a timestamp bookmark is present, the query looks like

```
SELECT ... WHERE column_name - CURRENT TIMEZONE >= value
```

I confirmed that before this change, when my `state.json` file used the most recent timestamp from a table, no records were returned during the next sync. After this change, all records where the timestamp matched the bookmark value were returned.